### PR TITLE
add ra4, gI, gA drag tables and sources where available

### DIFF
--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -13,18 +13,18 @@ enum DragTableId {
 
   g8,
 
-  /// Sphere (musket ball)
+  /// Sphere
   gS,
 
-  /// Cylinder (wad cutter)
+  /// Cylinder
   gC,
 
   gI,
 
-  /// Airgun pellets
+  /// Airgun Pellets
   gA,
 
-  /// .22LR
+  /// 22 LR
   ra4,
 }
 

--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -1,13 +1,27 @@
 enum DragTableId {
+  /// FB Spitzer
   g1,
+
   g2,
+
   g5,
+
   g6,
+
+  /// Boattail
   g7,
+
   g8,
+
+  /// Sphere (musket ball)
   gS,
+
+  /// Cylinder (wad cutter)
   gC,
+
   gI,
+
+  /// .22LR
   ra4,
 }
 

--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -7,6 +7,7 @@ enum DragTableId {
   g8,
   gS,
   gC,
+  gI,
   ra4,
 }
 
@@ -79,6 +80,8 @@ DragFunction dragFunctionFactory(DragTableId dragTable) {
       return (mach) => calculateByCurve(gSTable, gSCurve, mach);
     case DragTableId.gC:
       throw UnimplementedError('$dragTable not implemented');
+    case DragTableId.gI:
+      return (mach) => calculateByCurve(gITable, gICurve, mach);
     case DragTableId.ra4:
       return (mach) => calculateByCurve(ra4Table, ra4Curve, mach);
   }
@@ -745,7 +748,94 @@ List<DataPoint> gSTable = [
 
 List<CurvePoint> gSCurve = calculateCurve(gSTable);
 
-// source: https://jbmballistics.com/ballistics/downloads/downloads.shtml
+// source: https://jbmballistics.com/ballistics/downloads/text/mcgi.txt
+List<DataPoint> gITable = [
+  DataPoint(A: 0.00, B: 0.2282),
+  DataPoint(A: 0.05, B: 0.2282),
+  DataPoint(A: 0.10, B: 0.2282),
+  DataPoint(A: 0.15, B: 0.2282),
+  DataPoint(A: 0.20, B: 0.2282),
+  DataPoint(A: 0.25, B: 0.2282),
+  DataPoint(A: 0.30, B: 0.2282),
+  DataPoint(A: 0.35, B: 0.2282),
+  DataPoint(A: 0.40, B: 0.2282),
+  DataPoint(A: 0.45, B: 0.2282),
+  DataPoint(A: 0.50, B: 0.2282),
+  DataPoint(A: 0.55, B: 0.2282),
+  DataPoint(A: 0.60, B: 0.2282),
+  DataPoint(A: 0.65, B: 0.2282),
+  DataPoint(A: 0.70, B: 0.2282),
+  DataPoint(A: 0.725, B: 0.2353),
+  DataPoint(A: 0.75, B: 0.2434),
+  DataPoint(A: 0.775, B: 0.2515),
+  DataPoint(A: 0.80, B: 0.2596),
+  DataPoint(A: 0.825, B: 0.2677),
+  DataPoint(A: 0.85, B: 0.2759),
+  DataPoint(A: 0.875, B: 0.2913),
+  DataPoint(A: 0.90, B: 0.3170),
+  DataPoint(A: 0.925, B: 0.3442),
+  DataPoint(A: 0.95, B: 0.3728),
+  DataPoint(A: 1.0, B: 0.4349),
+  DataPoint(A: 1.05, B: 0.5034),
+  DataPoint(A: 1.075, B: 0.5402),
+  DataPoint(A: 1.10, B: 0.5756),
+  DataPoint(A: 1.125, B: 0.5887),
+  DataPoint(A: 1.15, B: 0.6018),
+  DataPoint(A: 1.175, B: 0.6149),
+  DataPoint(A: 1.20, B: 0.6279),
+  DataPoint(A: 1.225, B: 0.6418),
+  DataPoint(A: 1.25, B: 0.6423),
+  DataPoint(A: 1.30, B: 0.6423),
+  DataPoint(A: 1.35, B: 0.6423),
+  DataPoint(A: 1.40, B: 0.6423),
+  DataPoint(A: 1.45, B: 0.6423),
+  DataPoint(A: 1.50, B: 0.6423),
+  DataPoint(A: 1.55, B: 0.6423),
+  DataPoint(A: 1.60, B: 0.6423),
+  DataPoint(A: 1.625, B: 0.6407),
+  DataPoint(A: 1.65, B: 0.6378),
+  DataPoint(A: 1.70, B: 0.6321),
+  DataPoint(A: 1.75, B: 0.6266),
+  DataPoint(A: 1.80, B: 0.6213),
+  DataPoint(A: 1.85, B: 0.6163),
+  DataPoint(A: 1.90, B: 0.6113),
+  DataPoint(A: 1.95, B: 0.6066),
+  DataPoint(A: 2.00, B: 0.6020),
+  DataPoint(A: 2.05, B: 0.5976),
+  DataPoint(A: 2.10, B: 0.5933),
+  DataPoint(A: 2.15, B: 0.5891),
+  DataPoint(A: 2.20, B: 0.5850),
+  DataPoint(A: 2.25, B: 0.5811),
+  DataPoint(A: 2.30, B: 0.5773),
+  DataPoint(A: 2.35, B: 0.5733),
+  DataPoint(A: 2.40, B: 0.5679),
+  DataPoint(A: 2.45, B: 0.5626),
+  DataPoint(A: 2.50, B: 0.5576),
+  DataPoint(A: 2.60, B: 0.5478),
+  DataPoint(A: 2.70, B: 0.5386),
+  DataPoint(A: 2.80, B: 0.5298),
+  DataPoint(A: 2.90, B: 0.5215),
+  DataPoint(A: 3.00, B: 0.5136),
+  DataPoint(A: 3.10, B: 0.5061),
+  DataPoint(A: 3.20, B: 0.4989),
+  DataPoint(A: 3.30, B: 0.4921),
+  DataPoint(A: 3.40, B: 0.4855),
+  DataPoint(A: 3.50, B: 0.4792),
+  DataPoint(A: 3.60, B: 0.4732),
+  DataPoint(A: 3.70, B: 0.4674),
+  DataPoint(A: 3.80, B: 0.4618),
+  DataPoint(A: 3.90, B: 0.4564),
+  DataPoint(A: 4.00, B: 0.4513),
+  DataPoint(A: 4.20, B: 0.4415),
+  DataPoint(A: 4.40, B: 0.4323),
+  DataPoint(A: 4.60, B: 0.4238),
+  DataPoint(A: 4.80, B: 0.4157),
+  DataPoint(A: 5.00, B: 0.4082),
+];
+
+List<CurvePoint> gICurve = calculateCurve(gITable);
+
+// source: https://jbmballistics.com/ballistics/downloads/text/ra4.txt
 List<DataPoint> ra4Table = [
   DataPoint(A: 0.000, B: 0.2283),
   DataPoint(A: 0.050, B: 0.2283),

--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -7,6 +7,7 @@ enum DragTableId {
   g8,
   gS,
   gC,
+  ra4,
 }
 
 typedef DragFunction = double Function(double mach);
@@ -76,8 +77,10 @@ DragFunction dragFunctionFactory(DragTableId dragTable) {
       return (mach) => calculateByCurve(g8Table, g8Curve, mach);
     case DragTableId.gS:
       return (mach) => calculateByCurve(gSTable, gSCurve, mach);
-    default:
-      throw ArgumentError('Unknown drag table type');
+    case DragTableId.gC:
+      throw UnimplementedError('$dragTable not implemented');
+    case DragTableId.ra4:
+      return (mach) => calculateByCurve(ra4Table, ra4Curve, mach);
   }
 }
 
@@ -741,6 +744,99 @@ List<DataPoint> gSTable = [
 ];
 
 List<CurvePoint> gSCurve = calculateCurve(gSTable);
+
+// source: https://jbmballistics.com/ballistics/downloads/downloads.shtml
+List<DataPoint> ra4Table = [
+  DataPoint(A: 0.000, B: 0.2283),
+  DataPoint(A: 0.050, B: 0.2283),
+  DataPoint(A: 0.100, B: 0.2282),
+  DataPoint(A: 0.150, B: 0.2281),
+  DataPoint(A: 0.200, B: 0.2281),
+  DataPoint(A: 0.250, B: 0.2281),
+  DataPoint(A: 0.300, B: 0.2281),
+  DataPoint(A: 0.350, B: 0.2281),
+  DataPoint(A: 0.400, B: 0.2281),
+  DataPoint(A: 0.450, B: 0.2281),
+  DataPoint(A: 0.500, B: 0.2281),
+  DataPoint(A: 0.550, B: 0.2281),
+  DataPoint(A: 0.600, B: 0.2281),
+  DataPoint(A: 0.650, B: 0.2281),
+  DataPoint(A: 0.700, B: 0.2288),
+  DataPoint(A: 0.725, B: 0.2296),
+  DataPoint(A: 0.750, B: 0.2307),
+  DataPoint(A: 0.775, B: 0.2320),
+  DataPoint(A: 0.800, B: 0.2334),
+  DataPoint(A: 0.825, B: 0.2359),
+  DataPoint(A: 0.850, B: 0.2389),
+  DataPoint(A: 0.875, B: 0.2480),
+  DataPoint(A: 0.900, B: 0.2604),
+  DataPoint(A: 0.925, B: 0.2819),
+  DataPoint(A: 0.950, B: 0.3111),
+  DataPoint(A: 0.975, B: 0.3496),
+  DataPoint(A: 1.000, B: 0.3975),
+  DataPoint(A: 1.025, B: 0.4530),
+  DataPoint(A: 1.050, B: 0.5010),
+  DataPoint(A: 1.075, B: 0.5476),
+  DataPoint(A: 1.100, B: 0.5719),
+  DataPoint(A: 1.125, B: 0.5895),
+  DataPoint(A: 1.150, B: 0.5943),
+  DataPoint(A: 1.175, B: 0.5933),
+  DataPoint(A: 1.200, B: 0.5881),
+  DataPoint(A: 1.225, B: 0.5810),
+  DataPoint(A: 1.250, B: 0.5736),
+  DataPoint(A: 1.275, B: 0.5690),
+  DataPoint(A: 1.300, B: 0.5651),
+  DataPoint(A: 1.325, B: 0.5629),
+  DataPoint(A: 1.350, B: 0.5609),
+  DataPoint(A: 1.375, B: 0.5591),
+  DataPoint(A: 1.400, B: 0.5575),
+  DataPoint(A: 1.425, B: 0.5558),
+  DataPoint(A: 1.450, B: 0.5543),
+  DataPoint(A: 1.475, B: 0.5527),
+  DataPoint(A: 1.500, B: 0.5513),
+  DataPoint(A: 1.525, B: 0.5499),
+  DataPoint(A: 1.550, B: 0.5485),
+  DataPoint(A: 1.575, B: 0.5472),
+  DataPoint(A: 1.600, B: 0.5460),
+  DataPoint(A: 1.625, B: 0.5449),
+  DataPoint(A: 1.650, B: 0.5438),
+  DataPoint(A: 1.675, B: 0.5428),
+  DataPoint(A: 1.700, B: 0.5419),
+  DataPoint(A: 1.725, B: 0.5410),
+  DataPoint(A: 1.750, B: 0.5401),
+  DataPoint(A: 1.775, B: 0.5393),
+  DataPoint(A: 1.800, B: 0.5385),
+  DataPoint(A: 1.825, B: 0.5377),
+  DataPoint(A: 1.850, B: 0.5369),
+  DataPoint(A: 1.875, B: 0.5361),
+  DataPoint(A: 1.900, B: 0.5354),
+  DataPoint(A: 1.925, B: 0.5346),
+  DataPoint(A: 1.950, B: 0.5338),
+  DataPoint(A: 2.000, B: 0.5323),
+  DataPoint(A: 2.100, B: 0.5294),
+  DataPoint(A: 2.200, B: 0.5267),
+  DataPoint(A: 2.300, B: 0.5240),
+  DataPoint(A: 2.400, B: 0.5216),
+  DataPoint(A: 2.500, B: 0.5193),
+  DataPoint(A: 2.600, B: 0.5170),
+  DataPoint(A: 2.650, B: 0.5160),
+  DataPoint(A: 2.700, B: 0.5149),
+  DataPoint(A: 2.800, B: 0.5129),
+  DataPoint(A: 2.900, B: 0.5109),
+  DataPoint(A: 3.000, B: 0.5091),
+  DataPoint(A: 3.100, B: 0.5074),
+  DataPoint(A: 3.200, B: 0.5058),
+  DataPoint(A: 3.300, B: 0.5043),
+  DataPoint(A: 3.400, B: 0.5029),
+  DataPoint(A: 3.500, B: 0.5017),
+  DataPoint(A: 3.600, B: 0.5006),
+  DataPoint(A: 3.700, B: 0.4995),
+  DataPoint(A: 3.800, B: 0.4986),
+  DataPoint(A: 3.900, B: 0.4977),
+  DataPoint(A: 4.000, B: 0.4969),
+];
+
+List<CurvePoint> ra4Curve = calculateCurve(ra4Table);
 
 List<CurvePoint> calculateCurve(List<DataPoint> dataPoints) {
   List<CurvePoint> curve = [];

--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -21,6 +21,9 @@ enum DragTableId {
 
   gI,
 
+  /// Airgun pellets
+  gA,
+
   /// .22LR
   ra4,
 }
@@ -96,6 +99,8 @@ DragFunction dragFunctionFactory(DragTableId dragTable) {
       throw UnimplementedError('$dragTable not implemented');
     case DragTableId.gI:
       return (mach) => calculateByCurve(gITable, gICurve, mach);
+    case DragTableId.gA:
+      return (mach) => calculateByCurve(gATable, gACurve, mach);
     case DragTableId.ra4:
       return (mach) => calculateByCurve(ra4Table, ra4Curve, mach);
   }
@@ -947,6 +952,49 @@ List<DataPoint> ra4Table = [
 ];
 
 List<CurvePoint> ra4Curve = calculateCurve(ra4Table);
+
+// source: https://www.gatewaytoairguns.org/GTA/index.php?topic=159961
+List<DataPoint> gATable = [
+  DataPoint(A: 0.000, B: 0.250),
+  DataPoint(A: 0.100, B: 0.235),
+  DataPoint(A: 0.200, B: 0.221),
+  DataPoint(A: 0.300, B: 0.207),
+  DataPoint(A: 0.400, B: 0.196),
+  DataPoint(A: 0.500, B: 0.189),
+  DataPoint(A: 0.600, B: 0.189),
+  DataPoint(A: 0.700, B: 0.202),
+  DataPoint(A: 0.800, B: 0.241),
+  DataPoint(A: 0.900, B: 0.329),
+  DataPoint(A: 1.000, B: 0.488),
+  DataPoint(A: 1.100, B: 0.597),
+  DataPoint(A: 1.200, B: 0.649),
+  DataPoint(A: 1.300, B: 0.669),
+  DataPoint(A: 1.400, B: 0.672),
+  DataPoint(A: 1.500, B: 0.667),
+  DataPoint(A: 1.600, B: 0.657),
+  DataPoint(A: 1.700, B: 0.644),
+  DataPoint(A: 1.800, B: 0.630),
+  DataPoint(A: 1.900, B: 0.616),
+  DataPoint(A: 2.000, B: 0.602),
+  DataPoint(A: 2.100, B: 0.589),
+  DataPoint(A: 2.200, B: 0.577),
+  DataPoint(A: 2.300, B: 0.566),
+  DataPoint(A: 2.400, B: 0.556),
+  DataPoint(A: 2.500, B: 0.548),
+  DataPoint(A: 2.600, B: 0.540),
+  DataPoint(A: 2.700, B: 0.534),
+  DataPoint(A: 2.800, B: 0.529),
+  DataPoint(A: 2.900, B: 0.524),
+  DataPoint(A: 3.000, B: 0.521),
+  DataPoint(A: 3.100, B: 0.521),
+  DataPoint(A: 3.200, B: 0.517),
+  DataPoint(A: 3.300, B: 0.514),
+  DataPoint(A: 3.400, B: 0.510),
+  DataPoint(A: 3.500, B: 0.507),
+  DataPoint(A: 3.600, B: 0.503),
+];
+
+List<CurvePoint> gACurve = calculateCurve(ra4Table);
 
 List<CurvePoint> calculateCurve(List<DataPoint> dataPoints) {
   List<CurvePoint> curve = [];

--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -151,6 +151,7 @@ class CurvePoint {
 
 const double pir = 2.08551e-04;
 
+// source: https://jbmballistics.com/ballistics/downloads/text/mcg1.txt
 List<DataPoint> g1Table = [
   DataPoint(A: 0.00, B: 0.2629),
   DataPoint(A: 0.05, B: 0.2558),
@@ -235,6 +236,7 @@ List<DataPoint> g1Table = [
 
 List<CurvePoint> g1Curve = calculateCurve(g1Table);
 
+// source: https://jbmballistics.com/ballistics/downloads/text/mcg7.txt
 List<DataPoint> g7Table = [
   DataPoint(A: 0.00, B: 0.1198),
   DataPoint(A: 0.05, B: 0.1197),
@@ -324,6 +326,7 @@ List<DataPoint> g7Table = [
 
 List<CurvePoint> g7Curve = calculateCurve(g7Table);
 
+// source: https://jbmballistics.com/ballistics/downloads/text/mcg2.txt
 List<DataPoint> g2Table = [
   DataPoint(A: 0.00, B: 0.2303),
   DataPoint(A: 0.05, B: 0.2298),
@@ -414,6 +417,7 @@ List<DataPoint> g2Table = [
 
 List<CurvePoint> g2Curve = calculateCurve(g2Table);
 
+// source: https://jbmballistics.com/ballistics/downloads/text/mcg5.txt
 List<DataPoint> g5Table = [
   DataPoint(A: 0.00, B: 0.1710),
   DataPoint(A: 0.05, B: 0.1719),
@@ -495,6 +499,7 @@ List<DataPoint> g5Table = [
 
 List<CurvePoint> g5Curve = calculateCurve(g5Table);
 
+// source: https://jbmballistics.com/ballistics/downloads/text/mcg6.txt
 List<DataPoint> g6Table = [
   DataPoint(A: 0.00, B: 0.2617),
   DataPoint(A: 0.05, B: 0.2553),
@@ -579,6 +584,7 @@ List<DataPoint> g6Table = [
 
 List<CurvePoint> g6Curve = calculateCurve(g6Table);
 
+// https://jbmballistics.com/ballistics/downloads/text/mcg8.txt
 List<DataPoint> g8Table = [
   DataPoint(A: 0.00, B: 0.2105),
   DataPoint(A: 0.05, B: 0.2105),

--- a/lib/src/drag.dart
+++ b/lib/src/drag.dart
@@ -994,7 +994,7 @@ List<DataPoint> gATable = [
   DataPoint(A: 3.600, B: 0.503),
 ];
 
-List<CurvePoint> gACurve = calculateCurve(ra4Table);
+List<CurvePoint> gACurve = calculateCurve(gATable);
 
 List<CurvePoint> calculateCurve(List<DataPoint> dataPoints) {
   List<CurvePoint> curve = [];


### PR DESCRIPTION
This pull request adds support for several new drag models to the `drag.dart` module, expanding the set of ballistic drag tables available. It introduces new drag table identifiers, provides corresponding data tables and curve calculations, and updates the drag function factory to handle these new types.

**Support for new drag models:**

* Added new drag table IDs to the `DragTableId` enum: `gI` (source: mcgi), `gA` (airgun pellets), and `ra4` (.22 LR), along with comments for documentation.
* Added data tables and curve calculations for `gI`, `gA`, and `ra4`, including source references for traceability. [[1]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R776-R998) [[2]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R606) [[3]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R348) [[4]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R258) [[5]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R173) [[6]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R439) [[7]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R521)
* Updated `dragFunctionFactory` to support the new drag tables, returning the appropriate function for each and throwing an `UnimplementedError` for `gC` (cylinder) as a placeholder.

**Documentation and traceability:**

* Added source URLs as comments above each drag table definition for easier verification and maintenance. [[1]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R173) [[2]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R258) [[3]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R348) [[4]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R439) [[5]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R521) [[6]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R606) [[7]](diffhunk://#diff-b36d57f765653d62618655da20d776cd13bbe79e97acdcdcb929e9f8a3964519R776-R998)

**Bug fix:**

* Fixed a likely copy-paste bug by ensuring `gACurve` is calculated from `gATable` instead of `ra4Table`.

These changes make the drag model system more comprehensive and maintainable, allowing for more accurate ballistic calculations across a wider range of projectiles.